### PR TITLE
sanitized_value should not remove cjk character

### DIFF
--- a/actionview/lib/action_view/helpers/tags/base.rb
+++ b/actionview/lib/action_view/helpers/tags/base.rb
@@ -114,7 +114,7 @@ module ActionView
         end
 
         def sanitized_value(value)
-          value.to_s.gsub(/\s/, "_").gsub(/[^-\w]/, "").downcase
+          value.to_s.gsub(/\s/, "_").gsub(/[^-\p{Word}]/, "").downcase
         end
 
         def select_content_tag(option_tags, options, html_options)


### PR DESCRIPTION
according to http://www.w3.org/TR/html-markup/syntax.html#syntax-text

> Text in element contents (including in comments) and attribute values must consist of Unicode characters, with the following restrictions:
> - must not contain U+0000 characters
> - must not contain permanently undefined Unicode characters
> - must not contain control characters other than space characters
